### PR TITLE
add support for yielding exception objects and allowing generator to continue (optional, disabled by default)

### DIFF
--- a/knesset_data/dataservice/base.py
+++ b/knesset_data/dataservice/base.py
@@ -6,7 +6,7 @@ import logging
 from knesset_data.dataservice.constants import SERVICE_URLS
 import knesset_data.dataservice.utils as ds_utils
 from knesset_data.utils.github import github_add_or_update_issue
-from knesset_data.dataservice.exceptions import KnessetDataServiceRequestException
+from knesset_data.dataservice.exceptions import KnessetDataServiceRequestException, KnessetDataServiceObjectException
 from copy import deepcopy
 from collections import OrderedDict
 
@@ -225,12 +225,18 @@ class BaseKnessetDataServiceCollectionObject(BaseKnessetDataServiceObject):
         return url
 
     @classmethod
-    def _parse_entry(cls, entry):
-        entry_id = entry.id.string
-        entry_links = []
-        for link in entry.find_all('link'):
-            entry_links.append({'href': link.attrs['href'], 'rel': link.attrs['rel'][0],
-                                'title': link.attrs['title']})
+    def _parse_entry_id(cls, entry):
+        return entry.id.string
+
+    @classmethod
+    def _parse_entry_links(cls, entry):
+        return [{"href": link.attrs["href"],
+                 "rel": link.attrs["rel"][0],
+                 "title": link.attrs["title"]}
+                for link in entry.find_all('link')]
+
+    @classmethod
+    def _parse_entry_data(cls, entry):
         data = {}
         for prop in entry.content.find('m:properties').children:
             if isinstance(prop, Tag):
@@ -238,19 +244,37 @@ class BaseKnessetDataServiceCollectionObject(BaseKnessetDataServiceObject):
                 prop_type = prop.attrs.get('m:type', '')
                 prop_null = (prop.attrs.get('m:null', '') == 'true')
                 data[prop_name] = cls._handle_prop(prop_type, prop_null, prop)
+        return data
+
+    @classmethod
+    def _parse_entry(cls, entry):
         return {
-            'id': entry_id,
-            'links': entry_links,
-            'data': data,
+            'id': cls._parse_entry_id(entry),
+            'links': cls._parse_entry_links(entry),
+            'data': cls._parse_entry_data(entry),
         }
 
     @classmethod
-    def _get_all_pages(cls, start_url, params=None, proxies=None):
+    def _get_instance_from_entry(cls, entry, skip_exceptions=False):
+        try:
+            return cls(cls._parse_entry(entry))
+        except Exception, e:
+            if skip_exceptions:
+                return KnessetDataServiceObjectException(cls, entry, e)
+            else:
+                raise e
+
+    @classmethod
+    def _get_all_pages(cls, start_url, params=None, proxies=None, skip_exceptions=False):
         """
         This method is not exposed externally because it might be dangerous
         it will iterate over all the pages, starting at start_url, following next url in each xml
         it's dangerous because there is no stop condition
         so be sure to use it only with some kind of filter in the url to limit number of results
+        this function returns a generator yielding dataservice object instances
+        in case of exception in getting the http response - it will raise the exception directly
+        in case of exception in parsing the entry, behavior depends on skip_exceptions param
+        if False - will raise exception directly, otherwise - yields an KnessetDataServiceObjectException instance
         """
         # Composing URL in advance since the link to the next page already have the params of the
         # first request and using `get_soup` with the params argument creates duplicate params
@@ -258,17 +282,28 @@ class BaseKnessetDataServiceCollectionObject(BaseKnessetDataServiceObject):
         while next_url:
             soup = cls._get_soup(next_url, proxies=proxies)
             for entry in soup.feed.find_all('entry'):
-                yield cls(cls._parse_entry(entry))
+                yield cls._get_instance_from_entry(entry, skip_exceptions=skip_exceptions)
             next_link = soup.find('link', rel="next")
             next_url = next_link and next_link.attrs.get('href', None)
 
     @classmethod
     def get(cls, id, proxies=None):
+        """
+        gets a single dataservice object by id
+        raises exception on any failure to fetch or parse the object
+        """
         soup = cls._get_soup(cls._get_url_single(id), proxies=proxies)
-        return cls(cls._parse_entry(soup.entry))
+        return cls._get_instance_from_entry(soup.entry, skip_exceptions=False)
 
     @classmethod
-    def get_page(cls, order_by=None, results_per_page=50, page_num=1, proxies=None):
+    def get_page(cls, order_by=None, results_per_page=50, page_num=1, proxies=None, skip_exceptions=False):
+        """
+        gets a page of results
+        returns a generator yielding object instances
+        in case of exception in getting the http response - will raise the exception directly
+        in case of exception getting the object, behavior depends on skip_exceptions param
+        if False - will raise exception, otherwise yields KnessetDataServiceObjectException instance
+        """
         if not order_by and cls.DEFAULT_ORDER_BY_FIELD:
             order_by = (cls.DEFAULT_ORDER_BY_FIELD, 'desc')
         if order_by:
@@ -277,14 +312,20 @@ class BaseKnessetDataServiceCollectionObject(BaseKnessetDataServiceObject):
             order_by = order_by_field, order_by_dir
         soup = cls._get_soup(cls._get_url_page(order_by, results_per_page, page_num), proxies=proxies)
         if len(soup.feed.find_all('link', attrs={'rel': 'next'})) > 0:
-            raise Exception(
-                'looks like you asked for too much results per page, 50 results per page usually works')
+            raise Exception('looks like you asked for too much results per page, 50 results per page usually works')
         else:
-            return (cls(cls._parse_entry(entry)) for entry in soup.feed.find_all('entry'))
+            return (cls._get_instance_from_entry(entry, skip_exceptions=skip_exceptions) for entry in soup.feed.find_all('entry'))
 
     @classmethod
-    def get_all(cls, proxies=None):
-        return cls._get_all_pages(cls._get_url_base(), proxies=proxies)
+    def get_all(cls, proxies=None, skip_exceptions=False):
+        """
+        use with caution - it will get all pages without a stop condition
+        returns a generator yielding object instances
+        in case of exception in getting the http response - will raise the exception directly
+        in case of exception getting the object, behavior depends on skip_exceptions param
+        if False - will raise exception, otherwise yields KnessetDataServiceObjectException instance
+        """
+        return cls._get_all_pages(cls._get_url_base(), proxies=proxies, skip_exceptions=skip_exceptions)
 
 
 class BaseKnessetDataServiceFunctionObject(BaseKnessetDataServiceObject):

--- a/knesset_data/dataservice/base.py
+++ b/knesset_data/dataservice/base.py
@@ -260,7 +260,7 @@ class BaseKnessetDataServiceCollectionObject(BaseKnessetDataServiceObject):
             return cls(cls._parse_entry(entry))
         except Exception, e:
             if skip_exceptions:
-                return KnessetDataServiceObjectException(cls, entry, e)
+                return KnessetDataServiceObjectException(cls, e, entry)
             else:
                 raise e
 

--- a/knesset_data/dataservice/exceptions.py
+++ b/knesset_data/dataservice/exceptions.py
@@ -14,3 +14,13 @@ class KnessetDataServiceRequestException(RequestException):
 
     def __str__(self):
         return "{}, {}".format(self.message, self.url)
+
+
+class KnessetDataServiceObjectException(Exception):
+
+    def __init__(self, cls, entry, original_exception, *args, **kwargs):
+        self.dataservice_class = cls
+        self.unparsed_entry = entry
+        self.original_exception = original_exception
+        self.message = self.original_exception.message
+        super(KnessetDataServiceObjectException, self).__init__(*args, **kwargs)

--- a/knesset_data/dataservice/exceptions.py
+++ b/knesset_data/dataservice/exceptions.py
@@ -18,7 +18,7 @@ class KnessetDataServiceRequestException(RequestException):
 
 class KnessetDataServiceObjectException(Exception):
 
-    def __init__(self, cls, entry, original_exception, *args, **kwargs):
+    def __init__(self, cls, original_exception, entry=None, *args, **kwargs):
         self.dataservice_class = cls
         self.unparsed_entry = entry
         self.original_exception = original_exception

--- a/knesset_data/dataservice/members.py
+++ b/knesset_data/dataservice/members.py
@@ -8,7 +8,7 @@ logger = logging.getLogger('knesset_data.dataservice.members')
 class Member(BaseKnessetDataServiceCollectionObject):
     SERVICE_NAME = "members"
     METHOD_NAME = "View_mk_individual"
-    DEFAULT_ORDER_BY_FIELD = "mk_individual_id"
+    DEFAULT_ORDER_BY_FIELD = "id"
 
     ORDERED_FIELDS = [
         ("id", KnessetDataServiceSimpleField('mk_individual_id', "integer")),

--- a/knesset_data/dataservice/mocks.py
+++ b/knesset_data/dataservice/mocks.py
@@ -1,0 +1,51 @@
+# this module is used by knesset-data-datapackage for testing
+# please try not to break backwards compatibility
+
+from knesset_data.dataservice.members import Member
+
+
+class MockMember(Member):
+    SOUP_MEMBER_IDS = range(200, 205)
+    EXCEPTION_ON_INIT_MEMBER_ID = 203
+    EXCEPTION_ON_PARSE_MEMBER_ID = 204
+    EXCEPTION_ON_GET_MEMBER_ID = 215
+
+    def __init__(self, entry):
+        if entry["data"]["mk_individual_id"] == self.EXCEPTION_ON_INIT_MEMBER_ID:
+            raise Exception("member with exception on init")
+        super(MockMember, self).__init__(entry)
+
+    @classmethod
+    def _parse_entry(cls, entry):
+        parsed_entry = super(MockMember, cls)._parse_entry(entry)
+        if parsed_entry["data"]["mk_individual_id"] == cls.EXCEPTION_ON_PARSE_MEMBER_ID:
+            raise Exception("member with exception on parse")
+        return parsed_entry
+
+    @classmethod
+    def _parse_entry_id(cls, entry):
+        return str(entry)
+
+    @classmethod
+    def _parse_entry_links(cls, entry):
+        return []
+
+    @classmethod
+    def _parse_entry_data(cls, entry):
+        data = {field._knesset_field_name: "" for field in cls.get_fields().values() if hasattr(field, "_knesset_field_name")}
+        data["mk_individual_id"] = entry
+        return data
+
+    @classmethod
+    def _get_soup(cls, url, params=None, proxies=None):
+        if "({})".format(cls.EXCEPTION_ON_GET_MEMBER_ID) in url:
+            raise Exception("member with exception on get")
+        else:
+            def find_all(feed_instance, name, attrs=None):
+                if name == "link":
+                    return []
+                else:
+                    return [i for i in cls.SOUP_MEMBER_IDS]
+            return type("MockSoup", (object,),
+                        {"feed": type("MockFeed", (object,),
+                                      {"find_all": find_all})()})

--- a/knesset_data/dataservice/mocks.py
+++ b/knesset_data/dataservice/mocks.py
@@ -41,6 +41,8 @@ class MockMember(Member):
         if "({})".format(cls.EXCEPTION_ON_GET_MEMBER_ID) in url:
             raise Exception("member with exception on get")
         else:
+            def find(soup_instance, name, **kwargs):
+                return None
             def find_all(feed_instance, name, attrs=None):
                 if name == "link":
                     return []
@@ -48,4 +50,5 @@ class MockMember(Member):
                     return [i for i in cls.SOUP_MEMBER_IDS]
             return type("MockSoup", (object,),
                         {"feed": type("MockFeed", (object,),
-                                      {"find_all": find_all})()})
+                                      {"find_all": find_all})(),
+                         "find": find})()

--- a/knesset_data/dataservice/tests/base/test_exceptions.py
+++ b/knesset_data/dataservice/tests/base/test_exceptions.py
@@ -1,8 +1,9 @@
 import unittest
 from datetime import datetime
+
 from knesset_data.dataservice.committees import Committee, CommitteeMeeting
-from knesset_data.dataservice.members import Member
 from knesset_data.dataservice.exceptions import KnessetDataServiceRequestException, KnessetDataServiceObjectException
+from knesset_data.dataservice.mocks import MockMember
 from knesset_data.utils.testutils import data_dependant_test
 
 
@@ -14,53 +15,6 @@ class CommitteeWithVeryShortTimeoutAndInvalidService(Committee):
 class CommitteeMeetingWithVeryShortTimeoutAndInvalidService(CommitteeMeeting):
     DEFAULT_REQUEST_TIMEOUT_SECONDS = 1
     METHOD_NAME = "FOOBARBAZBAX"
-
-
-class MockMember(Member):
-    SOUP_MEMBER_IDS = range(200, 205)
-    EXCEPTION_ON_INIT_MEMBER_ID = 203
-    EXCEPTION_ON_PARSE_MEMBER_ID = 204
-    EXCEPTION_ON_GET_MEMBER_ID = 215
-
-    def __init__(self, entry):
-        if entry["data"]["mk_individual_id"] == self.EXCEPTION_ON_INIT_MEMBER_ID:
-            raise Exception("member with exception on init")
-        super(MockMember, self).__init__(entry)
-
-    @classmethod
-    def _parse_entry(cls, entry):
-        parsed_entry = super(MockMember, cls)._parse_entry(entry)
-        if parsed_entry["data"]["mk_individual_id"] == cls.EXCEPTION_ON_PARSE_MEMBER_ID:
-            raise Exception("member with exception on parse")
-        return parsed_entry
-
-    @classmethod
-    def _parse_entry_id(cls, entry):
-        return str(entry)
-
-    @classmethod
-    def _parse_entry_links(cls, entry):
-        return []
-
-    @classmethod
-    def _parse_entry_data(cls, entry):
-        data = {field._knesset_field_name: "" for field in cls.get_fields().values() if hasattr(field, "_knesset_field_name")}
-        data["mk_individual_id"] = entry
-        return data
-
-    @classmethod
-    def _get_soup(cls, url, params=None, proxies=None):
-        if "({})".format(cls.EXCEPTION_ON_GET_MEMBER_ID) in url:
-            raise Exception("member with exception on get")
-        else:
-            def find_all(feed_instance, name, attrs=None):
-                if name == "link":
-                    return []
-                else:
-                    return [i for i in cls.SOUP_MEMBER_IDS]
-            return type("MockSoup", (object,),
-                        {"feed": type("MockFeed", (object,),
-                                      {"find_all": find_all})()})
 
 
 class TestDataServiceRequestExceptions(unittest.TestCase):

--- a/knesset_data/dataservice/tests/base/test_exceptions.py
+++ b/knesset_data/dataservice/tests/base/test_exceptions.py
@@ -1,7 +1,8 @@
 import unittest
 from datetime import datetime
 from knesset_data.dataservice.committees import Committee, CommitteeMeeting
-from knesset_data.dataservice.exceptions import KnessetDataServiceRequestException
+from knesset_data.dataservice.members import Member
+from knesset_data.dataservice.exceptions import KnessetDataServiceRequestException, KnessetDataServiceObjectException
 from knesset_data.utils.testutils import data_dependant_test
 
 
@@ -15,7 +16,76 @@ class CommitteeMeetingWithVeryShortTimeoutAndInvalidService(CommitteeMeeting):
     METHOD_NAME = "FOOBARBAZBAX"
 
 
+class MockMember(Member):
+    SOUP_MEMBER_IDS = range(200, 205)
+    EXCEPTION_ON_INIT_MEMBER_ID = 203
+    EXCEPTION_ON_PARSE_MEMBER_ID = 204
+    EXCEPTION_ON_GET_MEMBER_ID = 215
+
+    def __init__(self, entry):
+        if entry["data"]["mk_individual_id"] == self.EXCEPTION_ON_INIT_MEMBER_ID:
+            raise Exception("member with exception on init")
+        super(MockMember, self).__init__(entry)
+
+    @classmethod
+    def _parse_entry(cls, entry):
+        parsed_entry = super(MockMember, cls)._parse_entry(entry)
+        if parsed_entry["data"]["mk_individual_id"] == cls.EXCEPTION_ON_PARSE_MEMBER_ID:
+            raise Exception("member with exception on parse")
+        return parsed_entry
+
+    @classmethod
+    def _parse_entry_id(cls, entry):
+        return str(entry)
+
+    @classmethod
+    def _parse_entry_links(cls, entry):
+        return []
+
+    @classmethod
+    def _parse_entry_data(cls, entry):
+        data = {field._knesset_field_name: "" for field in cls.get_fields().values() if hasattr(field, "_knesset_field_name")}
+        data["mk_individual_id"] = entry
+        return data
+
+    @classmethod
+    def _get_soup(cls, url, params=None, proxies=None):
+        if "({})".format(cls.EXCEPTION_ON_GET_MEMBER_ID) in url:
+            raise Exception("member with exception on get")
+        else:
+            def find_all(feed_instance, name, attrs=None):
+                if name == "link":
+                    return []
+                else:
+                    return [i for i in cls.SOUP_MEMBER_IDS]
+            return type("MockSoup", (object,),
+                        {"feed": type("MockFeed", (object,),
+                                      {"find_all": find_all})()})
+
+
 class TestDataServiceRequestExceptions(unittest.TestCase):
+
+    def test_member_exception(self):
+        # get_page - raises an exception as soon as it's encountered
+        exception = None
+        try:
+            list(MockMember.get_page())
+        except Exception, e:
+            exception = e
+        self.assertEqual(exception.message, "member with exception on init")
+        # get - raises an exception as soon as it's encountered
+        exception = None
+        try:
+            MockMember.get(215)
+        except Exception, e:
+            exception = e
+        self.assertEqual(exception.message, "member with exception on get")
+
+    def test_member_skipped_exceptions(self):
+        # get_page with skip_exceptions - yields exception objects on error
+        self.assertEqual([o.message if isinstance(o, KnessetDataServiceObjectException) else o.id
+                          for o in MockMember.get_page(skip_exceptions=True)],
+                         [200, 201, 202, 'member with exception on init', 'member with exception on parse'])
 
     @data_dependant_test()
     def test_committee(self):


### PR DESCRIPTION
### reproduction steps
* make a call to get some dataservice objects which have an error in parsing / processing one of the items
  * for example:
  * `from knesset_data.dataservice.members import Member`
  * `print(list(Member.get_page()))`
  * exception raised

#### expected
* support for yielding the exception object instead of raising exception:
  * `print(list(Member.get_page(skip_exceptions=True)))`
  * no exception
  * results contains both Member objects, and KnessetDataServiceObjectException objects for the problematic objects

#### actual
* raises exception, stopping processing of items



