### PR TITLE
Fixes failures in parsing docx files using docx2txt

### DIFF
--- a/knesset_data/protocols/utils.py
+++ b/knesset_data/protocols/utils.py
@@ -5,6 +5,7 @@ import os
 import xml.etree.ElementTree as ET
 from .exceptions import AntiwordException
 import six
+import docx2txt
 
 # solve issues with unicode for python3/2
 if six.PY2:
@@ -42,6 +43,10 @@ def antiword(filename):
     logger.debug('len(xmldata) = '+str(len(xmldata)))
     os.remove(filename+'.awdb.xml')
     return xmldata
+
+
+def docx2txt_process(filename):
+    return docx2txt.process(filename)
 
 
 def fix_hyphens(text):

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
     url='https://github.com/hasadna/knesset-data-python',
     packages=find_packages(exclude=["tests", "test.*"]),
     install_requires=['beautifulsoup4', 'pyslet', 'requests', 'simplejson', 'pyth',
-                      'python-hebrew-numbers', 'cached-property', 'six'],
+                      'python-hebrew-numbers', 'cached-property', 'six', 'docx2txt'],
     extras_require={'develop': ["tox"]},
 )


### PR DESCRIPTION
@OriHoch

I found out that antiword fails on newer doc files downloaded from the Knesset website. This is a minimal fix that fall backs to the docx2txt python library to do the parsing when antiword fails. 

Also made sure that parts processing works.

(A matching knesset-data-pipelines PR is also on the way...)